### PR TITLE
Enhances for translation and contribution readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,15 @@ GoZen is an open-source video editor developed using the Godot game engine. The 
 
 To contribute to GoZen, make sure you have the following:
 
-- The latest version of Godot (version 4+);
-- Familiarity with GDScript and Godot;
+- [The latest version of Godot (version 4+)](https://godotengine.org/download/);
+- [Familiarity with GDScript and Godot](https://docs.godotengine.org/en/stable/);
 
 ## How to Contribute
 
-1. Fork the project on GitHub to create your own copy;
+1. [Fork the project on GitHub to create your own copy](https://github.com/VoylinsGamedevJourney/GoZen/fork);
 1. Create a new branch in your forked repository with a descriptive name for the changes you plan to make;
 1. Before submitting your changes, rebase your commits to ensure the branch consists of a maximum of one commit (unless multiple commits are justified);
-1. Open a pull request from your branch to the main repository;
+1. [Open a pull request from your branch to the main repository](https://github.com/VoylinsGamedevJourney/GoZen/compare);
 1. Wait for code review and feedback from the project maintainer (you will be notified through the pull request);
 1. Address any feedback or requested changes and update your pull request;
 1. Once your pull request is approved, it will be merged into the main repository;
@@ -29,6 +29,10 @@ For bug reports and feature requests, please follow the guidelines below:
 
 **Bug Reports:** Provide a clear and detailed description of the issue, including steps to reproduce it.
 **Feature Requests:** Clearly explain the desired feature and its expected benefits.
+
+### Translation contribution
+
+If you want to contribute with translation, then refer to [translation guide](translations/README.md).
 
 ### Code Reviews and Merging Process
 

--- a/translations/README.md
+++ b/translations/README.md
@@ -15,7 +15,7 @@ At this stage we have a couple of different languages available inside of the ed
 
 ## How to contribute
 
-Before contributing, you have to [fork this repository](https://github.com/VoylinsGamedevJourney/GoZen/fork) and create a new branch called something like `language-*language-code*-update` (for example, `language-uk_UA-update` when you updating existing translation or `language-uk_UA-addition` when you adding new one). Please refer to [Adding new translation](#adding-new-translation) or [Updating an already existing language](#updating-an-already-existing-translation) to know how to edit the YAML file correctly.
+Before contributing, you have to [fork this repository](https://github.com/VoylinsGamedevJourney/GoZen/fork) and create a new branch called something like `language-*language-code*-update` (for example, `language-uk_UA-update` when you updating existing translation or `language-uk_UA-addition` when you adding new one). Please refer to [Adding new translation](#adding-new-translation) or [Updating an already existing translation](#updating-an-already-existing-translation) to know how to edit the YAML file correctly.
 
 After you are done editing the YAML file you can create a pull request. Please only add the updated YAML file as we will handle the csv file and other project files.
 

--- a/translations/README.md
+++ b/translations/README.md
@@ -15,7 +15,7 @@ At this stage we have a couple of different languages available inside of the ed
 
 ## How to contribute
 
-Before contributing, you have to [fork this repository](https://github.com/VoylinsGamedevJourney/GoZen/fork) and create a new branch called something like `language-*language-code*-update` (for example, `language-uk_UA-update` when you updating existing translation or `language-uk_UA-addition` when you adding new one). Please refer to [New language](#adding-new-translation) or [Updating an already existing language](#updating-an-already-existing-translation) to know how to edit the YAML file correctly.
+Before contributing, you have to [fork this repository](https://github.com/VoylinsGamedevJourney/GoZen/fork) and create a new branch called something like `language-*language-code*-update` (for example, `language-uk_UA-update` when you updating existing translation or `language-uk_UA-addition` when you adding new one). Please refer to [Adding new translation](#adding-new-translation) or [Updating an already existing language](#updating-an-already-existing-translation) to know how to edit the YAML file correctly.
 
 After you are done editing the YAML file you can create a pull request. Please only add the updated YAML file as we will handle the csv file and other project files.
 

--- a/translations/README.md
+++ b/translations/README.md
@@ -1,51 +1,30 @@
-# Translations
+## Translations
 
-At this stage we have a couple of different languages available inside of the editor. 
+At this stage we have a couple of different languages available inside of the editor:
 
-- English;
-- Japanese;
-- French;
-- Dutch;
-- Chinese;
-- Polish;
-- German;
-- Brazilian Portuguese;
-- Ukranian;
-- Rusian.
-
-## All languages welcome!
-
-If you want to provide language support by entering your language or adjusting/adding to already existing languages, then please feel free to do so. No need to ask for permission. When adding/changing a language, please follow the guidelines bellow to create a smooth and effort free experience.
+- Brazilian Portuguese by: Wilker-uwu
+- Chinese by: Aappaapp
+- Dutch by: Voylin
+- English by: Voylin
+- French by: Slander, #Guigui
+- German by: Kiisu-Master
+- Japanese by: Voylin
+- Polish by: SzczurekYT
+- Russian by: Vovkiv
+- Ukrainian by: Vovkiv
 
 ## How to contribute
 
-Before contributing, you have to fork this repository and create a new branch called something like 'language_*language-code* update/addition'. Please refer to "New language" or "updating an already existing language" to know how to edit the YAML file correctly.
+Before contributing, you have to [fork this repository](https://github.com/VoylinsGamedevJourney/GoZen/fork) and create a new branch called something like `language-*language-code*-update` (for example, `language-uk_UA-update` when you updating existing translation or `language-uk_UA-addition` when you adding new one). Please refer to [New language](#adding-new-translation) or [Updating an already existing language](#updating-an-already-existing-translation) to know how to edit the YAML file correctly.
 
 After you are done editing the YAML file you can create a pull request. Please only add the updated YAML file as we will handle the csv file and other project files.
 
-### New language?
+### Adding new translation
 
-Run the python script "generate.py" by using "python generate.py" inside of the folder, select '2' and enter the official language code in plain text without any ' or " marks. Don't worry about the changes which need to be done inside any of the other project files as we will be adjusting those.
+Run the python script `generate.py` by using `python generate.py` inside of the folder, select `2` and enter the official language code (for list of language codes, refer to [Godot docs](https://docs.godotengine.org/en/stable/tutorials/i18n/locales.html)) in plain text without any `'` or `"` marks . Don't worry about the changes which need to be done inside any of the other project files as we will be adjusting those.
 
 This will create a new entry for all keys inside of the YAML file, add the words next to the language code of each key and you're done!
 
-### Updating an already existing language
+### Updating an already existing translation
 
-In the translation.yaml file you'll find empty/prefilled slots for each key which needs translation. You can fill in or edit the current translation. Some text editors support folding which may be helpful to only display the information which you want to see, but this is totally up to you.
-
-## Future languages
-
-We don't have any specific plans for adding more languages in the future. Language support will completely depend on the support of the community.
-
-## Current contributors
-
-- English: Voylin
-- Japanese: Voylin
-- French: Slander, #Guigui
-- Dutch: Voylin
-- Chinese: Aappaapp
-- Polish: SzczurekYT
-- German: Kiisu-Master
-- Brazilian Portuguese: Wilker-uwu
-- Ukranian: Vovkiv
-- Rusian: Vovkiv
+In the `translation.yaml` file you'll find empty/prefilled slots for each key which needs translation. You can fill in or edit the current translation. Some text editors support folding which may be helpful to only display the information which you want to see, but this is totally up to you.


### PR DESCRIPTION
TLDR: https://github.com/Vovkiv/GoZen-ru-uk/blob/master/translations/README.md see changes here and here: https://github.com/Vovkiv/GoZen-ru-uk/blob/master/CONTRIBUTING.md

So, I did some general enhances to documentation for CONTRIBUTION.md and translations/README.md
For CONTRIBUTION:
* Added link to download Godot to save some clicks for contributors. In future, you might want to consider to provide link to exact version that contributor need to use using this archive: https://godotengine.org/download/archive/
*  Added link to Godot docs. Again, to save some clicks.
* Added link to translations/readme to point out that contributor can help with translations.

For translations/readme:
* Some general styling. Like, for example, using code styling instead of italic for better highlighting.
* Merged list of available translations with who contributed to specific language, since I don't see any reason why they should be separated. Also sorted this list in alphabetical order. Also fixed typos for Russian and Ukrainian.
* Removed "Future languages" section, since it doesn't provide any meaningful information.
* Removed "All languages welcome!" section, since it is also doesn't contribute with any meaningful information.
* Added link to list of all available language codes on Godot docs. Because there several standards for language codes, we need to make sure that contributor will use right one.
* Renamed "New language?" to "Adding new translation"; "Updating an already existing language" to "Updating an already existing translation"
* Added jumping to section for "Adding new translation" and "Updating an existing translation", so user can click on them.

Some ideas that should be implemented later:
* Add link to download page to exact version of Godot that contributor need to use.
* Add option for translation contributors to add some way to feedback in translation files or in README file, like email or personal site link. And make this information visible, so if end user will catch some mistranslated or typo, they can open some "help" menu, see email link to translator and write email to them "Hey, I found typo! Can you fix it?"
* Add section how to test translation, once it become possible to do so.