### PR TITLE
Added windows compilation support with Msys2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,12 @@ function compile_gdextension() {
   git pull
   popd
 
+  local scons_extra_args=""
+
   echo "GDExtension compiling"
   echo "Select target platform:"
   echo "1. Linux"
-  echo "2. Windows (not-supported yet)"
+  echo "2. Windows (Msys2)"
   echo "3. Mac (not-supported yet)"
   read -p "> " platform
   case $platform in
@@ -46,8 +48,7 @@ function compile_gdextension() {
       ;;
     2)
       platform=windows
-      #echo "Windows export not supported yet!"
-      #exit 1
+      scons_extra_args="use_mingw=yes"
       ;;
     3)
       platform=macos
@@ -75,10 +76,24 @@ function compile_gdextension() {
       target=template_debug
       ;;
   esac
+
   echo "Enter amount of cores/thread for compiling:"
   read -p "> " num_jobs
+
+  echo "Build FFmpeg? (y/N)"
+  read -p "> " ffmpeg
+  case $ffmpeg in
+    y)
+      pushd src/bin/gde_ffmpeg/
+      ./build-ffmpeg.sh $platform $num_jobs || { echo "FFmpeg build failed"; exit 1; }
+      popd
+      ;;
+    *)
+      ;;
+  esac
+
   pushd src/bin/gde_ffmpeg/
-  scons -j $num_jobs target=$target platform=$platform
+  scons -j $num_jobs target=$target platform=$platform $scons_extra_args
   popd
 }
 

--- a/src/bin/gde_ffmpeg/SConstruct
+++ b/src/bin/gde_ffmpeg/SConstruct
@@ -7,16 +7,17 @@ env.Append(CPPPATH=["src/"])
 
 # Determine the platform and set the appropriate link flags
 platform = ARGUMENTS.get('platform', 'Linux')
+use_mingw = ARGUMENTS.get('use_mingw', 'no')
 if platform == "linux": # Linux
   print("Linux system detected")
   env.Append(LIBS=["avcodec", "avformat", "avfilter", "avdevice", "avutil", "swscale", "swresample"])
-elif platform == "windows": # Windows - not working
+elif platform == "windows": # Windows
   print("Windows system detected")
-  env.Execute("./build-ffmpeg.sh")
   env.Append(CPPPATH=["ffmpeg-bin/include"])
-  env.Append(LIBPATH=["ffmpeg-bin/lib"])
+  env.Append(LIBPATH=["ffmpeg-bin/bin"])
   env.Append(LIBS=["avcodec", "avformat", "avfilter", "avdevice", "avutil", "swscale", "swresample"])
-  env.Append(LINKFLAGS=["-lavcodec", "-lavformat", "-lavfilter", "-lavdevice", "-lavutil", "-lswscale", "-lswresample"])
+  if use_mingw == "no":
+    env.Append(LINKFLAGS=["avcodec.lib", "avformat.lib", "avfilter.lib", "avdevice.lib", "avutil.lib", "swscale.lib", "swresample.lib"])
 elif platform == "macos": # macOS - not working
   print("Mac system detected")
   env.Append(LIBS=["libavcodec", "libavformat", "libavfilter", "libavdevice", "libavutil", "libswscale", "libswresample"])

--- a/src/bin/gde_ffmpeg/build-ffmpeg.sh
+++ b/src/bin/gde_ffmpeg/build-ffmpeg.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 echo "Running FFmpeg builder ..."
+platform=$1
+num_jobs=${2:-6}
+
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+gdextension_dir="$script_dir/.."
 
 ffmpeg_source_folder="$script_dir/ffmpeg"
 ffmpeg_bin_folder="$script_dir/ffmpeg-bin"
@@ -11,6 +15,29 @@ cd "$ffmpeg_source_folder" || exit -1
 echo "Updating ffmpeg submodule ..."
 git pull
 
-./configure --prefix="$ffmpeg_bin_folder" --enable-shared --enable-gpl
-make -j 6
-make -j 6 install
+config_extra_args=""
+if [ "$platform" = "windows" ]; then
+    cross_prefix="/opt/bin/x86_64-w64-mingw32-"
+    config_extra_args="--cross-prefix="$cross_prefix" --arch=x86_64 --target-os=mingw32"
+fi
+
+echo "Configuring ffmpeg ..."
+./configure --prefix="$ffmpeg_bin_folder" --enable-gpl --enable-shared $config_extra_args || exit -1
+
+echo "Building ffmpeg ..."
+make -j $num_jobs || exit -1
+
+echo "Installing ffmpeg ..."
+make -j $num_jobs install || exit -1
+
+if [ "$platform" = "windows" ]; then
+    echo "Copying dlls to GDExtension dir ..."
+    cp -fu $ffmpeg_bin_folder/bin/*.dll $gdextension_dir
+
+    # Copy dlls from /mingw64/bin (Adding to 'PATH' environment variable doesn't work)
+    dll_path="/mingw64/bin"
+    dlls="zlib1.dll libiconv-2.dll libbz2-1.dll liblzma-5.dll libwinpthread-1.dll"
+    for dll in $dlls; do
+        cp -fu $dll_path/$dll $gdextension_dir
+    done
+fi

--- a/src/bin/gde_ffmpeg/build-ffmpeg.sh
+++ b/src/bin/gde_ffmpeg/build-ffmpeg.sh
@@ -17,7 +17,8 @@ git pull
 
 config_extra_args=""
 if [ "$platform" = "windows" ]; then
-    cross_prefix="/opt/bin/x86_64-w64-mingw32-"
+    export PATH="/opt/bin":$PATH
+    cross_prefix="x86_64-w64-mingw32-"
     config_extra_args="--cross-prefix="$cross_prefix" --arch=x86_64 --target-os=mingw32"
 fi
 

--- a/src/bin/gde_ffmpeg/src/gozen_pipe_renderer.cpp
+++ b/src/bin/gde_ffmpeg/src/gozen_pipe_renderer.cpp
@@ -22,7 +22,11 @@ void GoZenPipeRenderer::setup(String output, int frame_rate) {
   //UtilityFunctions::print(cmd.c_str());
 
   // Opening the pipe
+#ifdef _WIN32
+  ffmpegPipe = _popen(cmd.c_str(), "w");
+#else
   ffmpegPipe = popen(cmd.c_str(), "w");
+#endif
   if (!ffmpegPipe) {
     UtilityFunctions::printerr("Failed to open ffmpeg pipe!");
     exit(1);
@@ -47,7 +51,11 @@ void GoZenPipeRenderer::add_frame(Ref<Image> frame_image) {
 
 void GoZenPipeRenderer::finish_video() {
   if (ffmpegPipe) {
+#ifdef _WIN32
+    _pclose(ffmpegPipe);
+#else
     pclose(ffmpegPipe);
+#endif
     ffmpegPipe = nullptr;
     UtilityFunctions::print("ffmpeg is closed");
   }

--- a/src/bin/gde_ffmpeg/src/gozen_renderer.cpp
+++ b/src/bin/gde_ffmpeg/src/gozen_renderer.cpp
@@ -41,8 +41,10 @@ int GoZenRenderer::open_ffmpeg(Ref<GoZenRenderProfile> new_profile) {
   p_codec_context->pix_fmt = AV_PIX_FMT_YUV420P;
   p_codec_context->width = profile->video_size.x;
   p_codec_context->height = profile->video_size.y;
-  p_codec_context->time_base = (AVRational){1, profile->framerate};
-  p_codec_context->framerate = (AVRational){profile->framerate, 1};
+  p_codec_context->time_base.num = 1;
+  p_codec_context->time_base.den = profile->framerate;
+  p_codec_context->framerate.num = profile->framerate;
+  p_codec_context->framerate.den = 1;
   p_codec_context->gop_size = 10;
   p_codec_context->max_b_frames = 1;
  


### PR DESCRIPTION
Requires [Msys2](https://www.msys2.org/) with mingw64 toolchain.
```bash
pacman -S diffutils mingw-w64-x86_64-scons mingw-w64-cross-binutils mingw-w64-x86_64-yasm mingw-w64-x86_64-toolchain mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-xz mingw-w64-x86_64-winpthreads-git
```