### PR TITLE
Fix window maximize on windows

### DIFF
--- a/src/ui/screen_main/screen_main.tscn
+++ b/src/ui/screen_main/screen_main.tscn
@@ -23,8 +23,9 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 0
 
-[node name="TopBar" parent="VBox" instance=ExtResource("2_xllsp")]
+[node name="TopBar" parent="VBox" node_paths=PackedStringArray("resize_handles") instance=ExtResource("2_xllsp")]
 layout_mode = 2
+resize_handles = NodePath("../../ResizeHandles")
 
 [node name="Content" type="Control" parent="VBox"]
 unique_name_in_owner = true

--- a/src/ui/screen_main/scripts/main_resize_handles.gd
+++ b/src/ui/screen_main/scripts/main_resize_handles.gd
@@ -10,9 +10,6 @@ func _ready() -> void:
 	$Right.gui_input.connect(_on_gui_input.bind($Right))
 	$Bottom.gui_input.connect(_on_gui_input.bind($Bottom))
 	$Corner.gui_input.connect(_on_gui_input.bind($Corner))
-	
-	get_viewport().size_changed.connect(func():
-		visible = get_window().mode == Window.MODE_WINDOWED)
 
 
 ###############################################################

--- a/src/ui/screen_main/scripts/main_top_bar.gd
+++ b/src/ui/screen_main/scripts/main_top_bar.gd
@@ -1,5 +1,64 @@
 extends PanelContainer
 
+###############################################################
+#region Window Mode  ##########################################
+###############################################################
+
+@export var resize_handles: Control
+
+var _windowed_win_size: Vector2i = Vector2i(300, 100)
+var _windowed_win_pos: Vector2i = Vector2i(0, 0)
+var _win_mode: Window.Mode = Window.MODE_WINDOWED
+
+var win_mode: Window.Mode:
+	get:
+		return _win_mode
+
+	set(value):
+		if value == _win_mode: return
+
+		# store prev_mode and current win_mode
+		var prev_mode = _win_mode
+		_win_mode = value
+
+		if OS.get_name() != "Windows" or !get_window().borderless:
+			get_window().mode = value
+			return
+
+		# store window size in windowed mode
+		if prev_mode == Window.MODE_WINDOWED:
+			_windowed_win_pos = get_window().position
+			_windowed_win_size = get_window().size
+
+		if value == Window.MODE_MAXIMIZED:
+			get_window().borderless = false
+			get_window().mode = Window.MODE_MAXIMIZED
+			get_window().borderless = true
+			
+			# adjust mismatched window size and position
+			var usable_screen := DisplayServer.screen_get_usable_rect(get_window().current_screen)
+			get_window().position = usable_screen.position + Vector2i(1, 1)
+			get_window().size = usable_screen.size
+			return
+
+		if value == Window.MODE_WINDOWED:
+			get_window().borderless = false
+			get_window().mode = prev_mode	# window.mode is not set to maximized when borderless
+			get_window().mode = Window.MODE_WINDOWED
+			get_window().borderless = true
+			
+			# restore window size and position
+			get_window().size = _windowed_win_size
+			get_window().position = _windowed_win_pos
+			return
+
+		get_window().mode = value
+
+#endregion
+###############################################################
+#region Main  #################################################
+###############################################################
+
 var move_window := false
 var move_start: Vector2i
 
@@ -9,16 +68,21 @@ func _ready() -> void:
 	ProjectManager._on_project_loaded.connect(func(): 
 		$Margin/HBox/ProjectButton.visible = true)
 
+	assert(resize_handles, "Resize handles not assigned.")
+	get_viewport().size_changed.connect(func():
+		resize_handles.visible = win_mode == Window.MODE_WINDOWED and get_window().borderless
+	)
 
+#endregion
 ###############################################################
 #region Window Dragging  ######################################
 ###############################################################
 
 func _on_top_bar_dragging(event):
 	if event is InputEventMouseButton and event.button_index == 1:
-		if !move_window:
+		move_window = event.is_pressed() and win_mode == Window.MODE_WINDOWED
+		if move_window:
 			move_start = get_viewport().get_mouse_position()
-		move_window = event.is_pressed()
 
 
 func _process(_delta: float) -> void:
@@ -32,14 +96,14 @@ func _process(_delta: float) -> void:
 ###############################################################
 
 func _on_minimize_button_pressed():
-	get_window().set_mode(Window.MODE_MINIMIZED)
+	win_mode = Window.MODE_MINIMIZED
 
 
 func _on_switch_mode_button_pressed():
-	if get_window().mode == Window.MODE_WINDOWED:
-		get_window().set_mode(Window.MODE_FULLSCREEN)
-	elif get_window().mode == Window.MODE_FULLSCREEN:
-		get_window().set_mode(Window.MODE_WINDOWED)
+	if win_mode == Window.MODE_WINDOWED:
+		win_mode = Window.MODE_MAXIMIZED
+	else:
+		win_mode = Window.MODE_WINDOWED
 
 
 func _on_exit_button_pressed():


### PR DESCRIPTION
This PR adds a temporary fix for maximizing the window on windows. I've tested on Windows 11, Fedora KDE and OpenSUSE GNOME.
I've tried to keep the code as close to the original as possible. This should allow quick replacement of the code when the issue is fixed in godot itself.
There still exist slight issues like the windows 7 style title bar is displayed for 1 frame before the maximizing animation is played.
A major drawback of this fix is that `get_window().mode` does not return `Window.MODE_MAXIMIZED` even when the window is maximized. As a workaround `win_mode` variable is implemented with a getter and a setter.