### PR TITLE
Making Top Bar more modular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,3 @@ config.log
 *.exe
 *.out
 *.app
-
-
-# Custom ignores (Temporary)
-/OLD/
-/test_project/
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "src/bin/gde_ffmpeg/godot-cpp"]
+[submodule "godot-cpp"]
 	path = src/bin/gde_ffmpeg/godot-cpp
 	url = git@github.com:godotengine/godot-cpp.git
-[submodule "translations"]
-	path = src/translations
+[submodule "gozen-translations"]
+	path = src/translations/gozen-translations
 	url = git@github.com:VoylinsGamedevJourney/GoZen-translations.git
-[submodule "src/bin/gde_ffmpeg/ffmpeg"]
+[submodule "ffmpeg"]
 	path = src/bin/gde_ffmpeg/ffmpeg
 	url = git@github.com:FFmpeg/FFmpeg.git

--- a/src/autoloads/al_settings_manager.gd
+++ b/src/autoloads/al_settings_manager.gd
@@ -2,6 +2,8 @@ extends Node
 
 signal _on_language_changed(new_language: String)
 
+signal _on_top_bar_positions_changed
+
 
 var config := ConfigFile.new()
 
@@ -78,6 +80,36 @@ func get_default_audio_tracks() -> int:
 func set_default_audio_tracks(new_default: int) -> void:
 	config.set_value("timeline", "default_audio_tracks", new_default)
 	save_settings()
+
+#endregion
+###############################################################
+
+#################################################################
+##
+##      TOP BAR MENU  -  GETTERS AND SETTERS
+##
+#################################################################
+
+###############################################################
+#region Top Bar menu position  ################################
+###############################################################
+
+func get_top_bar_menu_position(button_name: String) -> int:
+	return config.get_value("top_bar", "button_%s" % button_name, 0)
+
+
+func set_top_bar_menu_position(button_name: String, new_pos: int) -> void:
+	# TODO: Add a way to change this through the settings menu.
+	# Best way to do this is get all section keys from section "top_bar", check
+	# if key starts with "button_". This way custom module buttons will also
+	# show up in the list, and just add those entries dynamically to the
+	# setings menu.
+	# 0 = display in menu only
+	# 1 = only next to editor button
+	# 2 = display on both places
+	config.set_value("top_bar", "button_%s" % button_name, new_pos)
+	save_settings()
+	_on_top_bar_positions_changed.emit()
 
 #endregion
 ###############################################################

--- a/src/ui/screen_main/components/main_top_bar.tscn
+++ b/src/ui/screen_main/components/main_top_bar.tscn
@@ -1,14 +1,11 @@
-[gd_scene load_steps=13 format=3 uid="uid://bwmh7ufcadx5v"]
+[gd_scene load_steps=10 format=3 uid="uid://bwmh7ufcadx5v"]
 
 [ext_resource type="Script" path="res://ui/screen_main/scripts/main_top_bar.gd" id="1_8vd8r"]
 [ext_resource type="Theme" uid="uid://wa3swx7ortc6" path="res://ui/screen_main/theming/main_top_bar.tres" id="1_d5ptb"]
 [ext_resource type="Script" path="res://ui/screen_main/scripts/main_top_bar_window_title.gd" id="3_mgbmc"]
 [ext_resource type="Texture2D" uid="uid://bdsvqibn5gh04" path="res://assets/icons/editor_icon.png" id="4_07ice"]
-[ext_resource type="Script" path="res://classes/button_open_link.gd" id="4_768jx"]
-[ext_resource type="Texture2D" uid="uid://bgrbdik8x3iqe" path="res://assets/icons/movie_edit.png" id="6_b7p0r"]
 [ext_resource type="Texture2D" uid="uid://bk66k38osgv0o" path="res://assets/icons/minimize.png" id="6_vtbfy"]
 [ext_resource type="Texture2D" uid="uid://cxdjexu1spc7o" path="res://assets/icons/maximize.png" id="7_7ncvm"]
-[ext_resource type="Texture2D" uid="uid://hav4onsqoo7i" path="res://assets/icons/settings_video_camera.png" id="7_w5c7v"]
 [ext_resource type="Texture2D" uid="uid://c1yn05a2gyiiy" path="res://assets/icons/close.png" id="8_fak1p"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_b1s40"]
@@ -42,32 +39,18 @@ size_flags_vertical = 4
 mouse_filter = 2
 theme_override_constants/separation = 4
 
-[node name="EditorButton" type="Button" parent="Margin/HBox"]
+[node name="TopEditorButton" type="MenuButton" parent="Margin/HBox"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 tooltip_text = "TOP_BAR_TOOLTIP_EDITOR_BUTTON"
 icon = ExtResource("4_07ice")
-flat = true
-icon_alignment = 1
-expand_icon = true
-script = ExtResource("4_768jx")
-link = "github_repo"
-
-[node name="ProjectButton" type="Button" parent="Margin/HBox"]
-custom_minimum_size = Vector2(26, 26)
-layout_mode = 2
-tooltip_text = "TOP_BAR_TOOLTIP_PROJECT_SETTINGS_BUTTON"
-icon = ExtResource("6_b7p0r")
 icon_alignment = 1
 expand_icon = true
 
-[node name="SettingsButton" type="Button" parent="Margin/HBox"]
-custom_minimum_size = Vector2(26, 26)
+[node name="TopMenuButtons" type="HBoxContainer" parent="Margin/HBox"]
+unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "TOP_BAR_TOOLTIP_SETTINGS_BUTTON"
-icon = ExtResource("7_w5c7v")
-icon_alignment = 1
-expand_icon = true
 
 [node name="Spacer" type="VSeparator" parent="Margin/HBox"]
 layout_mode = 2
@@ -79,26 +62,21 @@ theme_override_styles/separator = SubResource("StyleBoxEmpty_jlnuy")
 custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 icon = ExtResource("6_vtbfy")
-icon_alignment = 1
 expand_icon = true
 
 [node name="SwitchModeButton" type="Button" parent="Margin/HBox"]
 custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 icon = ExtResource("7_7ncvm")
-icon_alignment = 1
 expand_icon = true
 
 [node name="ExitButton" type="Button" parent="Margin/HBox"]
 custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 icon = ExtResource("8_fak1p")
-icon_alignment = 1
 expand_icon = true
 
 [connection signal="gui_input" from="." to="." method="_on_top_bar_dragging"]
-[connection signal="pressed" from="Margin/HBox/ProjectButton" to="." method="_on_project_button_pressed"]
-[connection signal="pressed" from="Margin/HBox/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="pressed" from="Margin/HBox/MinimizeButton" to="." method="_on_minimize_button_pressed"]
 [connection signal="pressed" from="Margin/HBox/SwitchModeButton" to="." method="_on_switch_mode_button_pressed"]
 [connection signal="pressed" from="Margin/HBox/ExitButton" to="." method="_on_exit_button_pressed"]

--- a/src/ui/screen_main/scripts/main_top_bar.gd
+++ b/src/ui/screen_main/scripts/main_top_bar.gd
@@ -1,6 +1,27 @@
 extends PanelContainer
-# MODULAR TODO: Create a way for modules to add icons
-#               between Spacer and SettingsButton
+# When adding buttons, add the buttons next to the editor button, but also in
+# the editor menu. Set the id and the function call in the variable dictionary
+# menu_buttons. Also, set a default in the settings for the top bar.
+
+var menu_buttons := []
+
+var move_window := false
+var move_start: Vector2i
+
+
+func _ready() -> void:
+	set_default_menu_buttons()
+	# TODO: Fetch all custom module buttons
+	set_button_positions()
+	print(%TopMenuButtons.get_children())
+	%TopMenuButtons.get_node("ProjectSettingsButton").visible = false
+	ProjectManager._on_project_loaded.connect(func(): 
+		%TopMenuButtons.get_node("ProjectSettingsButton").visible = true)
+	
+	assert(resize_handles, "Resize handles not assigned.")
+	get_viewport().size_changed.connect(func():
+		resize_handles.visible = win_mode == Window.MODE_WINDOWED and get_window().borderless
+	)
 
 
 ###############################################################
@@ -66,29 +87,10 @@ var win_mode: Window.Mode:
 
 #endregion
 ###############################################################
-#region Main  #################################################
-###############################################################
-
-var move_window := false
-var move_start: Vector2i
-
-
-func _ready() -> void:
-	$Margin/HBox/ProjectButton.visible = false
-	ProjectManager._on_project_loaded.connect(func(): 
-		$Margin/HBox/ProjectButton.visible = true)
-
-	assert(resize_handles, "Resize handles not assigned.")
-	get_viewport().size_changed.connect(func():
-		resize_handles.visible = win_mode == Window.MODE_WINDOWED and get_window().borderless
-	)
-
-#endregion
-###############################################################
 #region Window Dragging  ######################################
 ###############################################################
 
-func _on_top_bar_dragging(event):
+func _on_top_bar_dragging(event) -> void:
 	if event is InputEventMouseButton and event.button_index == 1:
 		move_window = event.is_pressed() and win_mode == Window.MODE_WINDOWED
 		if move_window:
@@ -105,18 +107,18 @@ func _process(_delta: float) -> void:
 #region Top Bar Window Buttons  ###############################
 ###############################################################
 
-func _on_minimize_button_pressed():
+func _on_minimize_button_pressed() -> void:
 	win_mode = Window.MODE_MINIMIZED
 
 
-func _on_switch_mode_button_pressed():
+func _on_switch_mode_button_pressed() -> void:
 	if win_mode == Window.MODE_WINDOWED:
 		win_mode = Window.MODE_MAXIMIZED
 	else:
 		win_mode = Window.MODE_WINDOWED
 
 
-func _on_exit_button_pressed():
+func _on_exit_button_pressed() -> void:
 	if ProjectManager.project_path == "":
 		get_tree().quit()
 		return
@@ -134,14 +136,83 @@ func _on_exit_button_pressed():
 
 #endregion
 ###############################################################
-#region Top Bar Setting Buttons  ##############################
+#region Top Bar Buttons  ######################################
 ###############################################################
 
-func _on_project_button_pressed():
+func set_default_menu_buttons() -> void:
+	%TopEditorButton.get_popup().id_pressed.connect(func(id: int):
+		menu_buttons[id].function.call())
+	SettingsManager._on_top_bar_positions_changed.connect(set_button_positions)
+	add_menu_button( # Project settings
+		"res://assets/icons/movie_edit.png",
+		"Project settings",
+		_on_project_button_pressed,
+		"todo: tooltip")
+	add_menu_button( # Settings
+		"res://assets/icons/settings_video_camera.png",
+		"Settings",
+		_on_settings_button_pressed,
+		"todo: tooltip")
+	if !SettingsManager.config.has_section("top_bar"):
+		SettingsManager.set_top_bar_menu_position("project_settings", 1)
+		SettingsManager.set_top_bar_menu_position("settings", 1)
+	elif !SettingsManager.config.get_section_keys("top_bar").has("button_project_settings"):
+		SettingsManager.set_top_bar_menu_position("project_settings", 1)
+	elif !SettingsManager.config.get_section_keys("top_bar").has("button_settings"):
+		SettingsManager.set_top_bar_menu_position("settings", 1)
+	add_separator("Modular entries")
+
+
+func add_menu_button(icon_path: String, title: String, function: Callable, tooltip: String) -> void:
+	var icon := ImageTexture.new()
+	var image: Image = Image.new()
+	image.load(icon_path)
+	icon.set_image(image)
+	
+	menu_buttons.append({
+		"icon": icon,
+		"title": title,
+		"function": function,
+		"tooltip": tooltip
+	})
+	var button := Button.new()
+	button.custom_minimum_size = Vector2i(26,26)
+	button.name = "%sButton" % title.capitalize().replace(" ", "")
+	button.tooltip_text = tooltip
+	button.icon = icon
+	button.expand_icon = true
+	button.pressed.connect(function)
+	%TopMenuButtons.add_child(button)
+
+
+func add_separator(title: String) -> void:
+	menu_buttons.append(title)
+
+
+func set_button_positions() -> void:
+	var menu: PopupMenu = %TopEditorButton.get_popup()
+	menu.clear()
+	for id in menu_buttons.size():
+		if menu_buttons[id] is String:
+			menu.add_separator(menu_buttons[id])
+			continue
+		var key: String = menu_buttons[id].title.to_lower().replace(" ", "_")
+		if SettingsManager.get_top_bar_menu_position(key) == 1:
+			continue
+		menu.add_item(menu_buttons[id].title, id)
+		menu.set_item_icon(id, menu_buttons[id].icon)
+		menu.set_item_tooltip(id, menu_buttons[id].tooltip)
+		if menu_buttons[id].title == "Project settings":
+			%TopEditorButton.get_popup().set_item_disabled(id, true)
+			ProjectManager._on_project_loaded.connect(func(): 
+				%TopEditorButton.get_popup().set_item_disabled(id, false))
+
+
+func _on_project_button_pressed() -> void:
 	ScreenMain.instance.show_screen(ScreenMain.SCREENS.PROJECT_SETTINGS)
 
 
-func _on_settings_button_pressed():
+func _on_settings_button_pressed() -> void:
 	ScreenMain.instance.show_screen(ScreenMain.SCREENS.SETTINGS)
 
 #endregion

--- a/src/ui/screen_main/theming/main_top_bar.tres
+++ b/src/ui/screen_main/theming/main_top_bar.tres
@@ -36,3 +36,7 @@ Button/styles/focus = SubResource("StyleBoxEmpty_43emp")
 Button/styles/hover = SubResource("StyleBoxFlat_urgjl")
 Button/styles/normal = SubResource("StyleBoxEmpty_4kvfj")
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_0ah4v")
+PopupMenu/colors/font_separator_color = Color(0.621094, 0.621094, 0.621094, 1)
+PopupMenu/constants/icon_max_width = 26
+PopupMenu/font_sizes/font_separator_size = 12
+PopupMenu/font_sizes/font_size = 14


### PR DESCRIPTION
This makes it possible to more easily add buttons to the top bar/menu.

There are still some TODO's to make this feature complete, such as:
- Checking if the custom module entries still exist or not;
- Adding an option to change where they display in the settings menu

The integer codes are:
0 = shows only in the popup menu
1 = shows only in the top bar
2 = shows in both locations 