### PR TITLE
Add GitHub workflows for building GoZen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,16 +34,16 @@ jobs:
           install: >-
             curl
             git
+            mingw-w64-cross-binutils
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-scons
+            mingw-w64-x86_64-yasm
+            diffutils
+            make
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Update pacman
-        shell: msys2 {0}
-        run: pacman -Suy
-      - name: Install stuff
-        shell: msys2 {0}
-        run: pacman -S --noconfirm mingw-w64-cross-binutils mingw-w64-x86_64-toolchain mingw-w64-x86_64-scons mingw-w64-x86_64-yasm diffutils make
       - name: Build FFmpeg
         run: pushd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && popd
       - name: Build GDExtension

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,5 @@ jobs:
         run: pip install scons
       - name: Setup FFmpeg
         run: sudo apt install -y ffmpeg
-      - run: cd ./GoZen
       - name: Build
         run: sh ./build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
+          location: D:\
           install: >-
             curl
             git
@@ -40,6 +41,7 @@ jobs:
             mingw-w64-x86_64-yasm
             diffutils
             make
+      - run: echo "D:\msys64\mingw64\bin\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ffmpeg-linux
-          path: src/bin/gde_ffmpeg
+          path: src/bin/gde_ffmpeg/libgozen*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Setup FFmpeg
         run: sudo apt install -y ffmpeg
       - name: Build
-        run: cd ./src/bin/gde_ffmpeg/ && scons target=template_release platform=linux
+        run: cd ./src/bin/gde_ffmpeg/ && ./build-ffmpeg.sh linux && scons target=template_release platform=linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Setup FFmpeg
         run: sudo apt install -y ffmpeg
       - name: Build
-        run: cd ./src/bin/gde_ffmpeg/ && scons -j 10 target=linux platform=linux
+        run: cd ./src/bin/gde_ffmpeg/ && scons -j 10 target=template_release platform=linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Python
+        uses: actions/setup-python@v5
+      - name: Setup SCons
+        run: pip install scons
+      - name: Setup FFmpeg
+        run: sudo apt install -y ffmpeg
+      - run: cd ./GoZen
+      - name: Build
+        run: sh ./build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build GDExtension
         run: pushd ./src/bin/gde_ffmpeg/ && scons target=template_release platform=linux use_ci=yes && popd
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ffmpeg-linux
-          path: src/bin/gde_ffmpeg/libgozen*
+          path: "**/libgozen*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Setup FFmpeg
         run: sudo apt install -y ffmpeg
       - name: Build
-        run: sh ./build.sh
+        run: cd ./src/bin/gde_ffmpeg/ && scons target=template_release platform=linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Setup Yasm
         run: sudo apt install -y yasm
       - name: Build FFmpeg
-        run: cd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh
+        run: pushd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && popd
       - name: Build GDExtension
-        run: scons target=template_release platform=linux use_ci=yes
+        run: pushd ./src/bin/gde_ffmpeg/ && scons target=template_release platform=linux use_ci=yes && popd
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,14 @@ jobs:
         uses: actions/setup-python@v5
       - name: Setup SCons
         run: pip install scons
-      - name: Setup FFmpeg
-        run: sudo apt install -y ffmpeg
-      - name: Build
-        run: cd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && scons -j 10 target=template_release platform=linux use_ci=yes
+      - name: Setup Yasm
+        run: sudo apt install -y yasm
+      - name: Build FFmpeg
+        run: cd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh
+      - name: Build GDExtension
+        run: scons target=template_release platform=linux use_ci=yes
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ffmpeg-linux
+          path: src/bin/gde_ffmpeg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,7 @@ jobs:
         run: pip install scons
       - name: Setup FFmpeg
         run: sudo apt install -y ffmpeg
+      - name: Setup yasm
+        run: sudo apt install -y yasm
       - name: Build
         run: cd ./src/bin/gde_ffmpeg/ && ./build-ffmpeg.sh linux && scons target=template_release platform=linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Python
@@ -27,10 +27,17 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        shell: bash
+        shell: msys2 {0}
     steps:
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            curl
+            git
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Update pacman

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,5 @@ jobs:
         run: pip install scons
       - name: Setup FFmpeg
         run: sudo apt install -y ffmpeg
-      - name: Setup yasm
-        run: sudo apt install -y yasm
       - name: Build
-        run: cd ./src/bin/gde_ffmpeg/ && ./build-ffmpeg.sh linux && scons target=template_release platform=linux
+        run: cd ./src/bin/gde_ffmpeg/ && scons -j 10 target=linux platform=linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Setup SCons
         run: pip install scons
       - name: Setup FFmpeg
-        run: sudo apt install -y ffmpeg
+        run: sudo apt update && sudo apt install -y ffmpeg
       - name: Build
         run: cd ./src/bin/gde_ffmpeg/ && scons -j 10 target=template_release platform=linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,31 @@ jobs:
         run: pushd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && popd
       - name: Build GDExtension
         run: pushd ./src/bin/gde_ffmpeg/ && scons target=template_release platform=linux use_ci=yes && popd
+      - name: Upload GDExtension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gdextension-linux
+          path: src/bin/libgozen*
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Update pacman
+        run: pacman -Suy
+      - name: Install stuff
+        run: pacman -S --noconfirm mingw-w64-cross-binutils mingw-w64-x86_64-toolchain mingw-w64-x86_64-scons mingw-w64-x86_64-yasm diffutils make
+      - name: Build FFmpeg
+        run: pushd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && popd
+      - name: Build GDExtension
+        run: pushd ./src/bin/gde_ffmpeg/ && scons target=template_release platform=linux use_ci=yes && popd
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ffmpeg-linux
-          path: "**/libgozen*"
+          name: ffmpeg-windows
+          path: src/bin/libgozen*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Setup SCons
         run: pip install scons
       - name: Setup FFmpeg
-        run: sudo apt update && sudo apt install -y ffmpeg
+        run: sudo apt install -y ffmpeg
       - name: Build
-        run: cd ./src/bin/gde_ffmpeg/ && scons -j 10 target=template_release platform=linux
+        run: cd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && scons -j 10 target=template_release platform=linux use_ci=yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,11 @@ jobs:
           path: src/bin/libgozen*
   windows:
     runs-on: windows-latest
-    defaults:
-      run:
-        shell: msys2 {0}
     steps:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
+          msystem: MINGW64
           update: true
           install: >-
             curl
@@ -41,8 +39,10 @@ jobs:
         with:
           submodules: recursive
       - name: Update pacman
+        shell: msys2 {0}
         run: pacman -Suy
       - name: Install stuff
+        shell: msys2 {0}
         run: pacman -S --noconfirm mingw-w64-cross-binutils mingw-w64-x86_64-toolchain mingw-w64-x86_64-scons mingw-w64-x86_64-yasm diffutils make
       - name: Build FFmpeg
         run: pushd ./src/bin/gde_ffmpeg/ && sh ./build-ffmpeg.sh && popd

--- a/src/bin/gde_ffmpeg/SConstruct
+++ b/src/bin/gde_ffmpeg/SConstruct
@@ -6,11 +6,15 @@ env.Append(CPPPATH=["src/"])
 
 
 # Determine the platform and set the appropriate link flags
+ci = ARGUMENTS.get('use_ci', 'no')
 platform = ARGUMENTS.get('platform', 'Linux')
 use_mingw = ARGUMENTS.get('use_mingw', 'no')
 if platform == "linux": # Linux
   print("Linux system detected")
   env.Append(LIBS=["avcodec", "avformat", "avfilter", "avdevice", "avutil", "swscale", "swresample"])
+  if ci == "yes":
+    env.Append(CPPPATH=["ffmpeg-bin/include"])
+    env.Append(LIBPATH=["ffmpeg-bin/bin"])
 elif platform == "windows": # Windows
   print("Windows system detected")
   # First compiling ffmpeg

--- a/src/bin/gde_ffmpeg/SConstruct
+++ b/src/bin/gde_ffmpeg/SConstruct
@@ -22,7 +22,7 @@ elif platform == "windows": # Windows
   env.Execute("./build-ffmpeg.sh " + str(num_jobs))
   # Adding libraries for building
   env.Append(CPPPATH=["ffmpeg-bin/include"])
-  env.Append(LIBPATH=["ffmpeg-bin/bin"])
+  env.Append(LIBPATH=["ffmpeg-bin/lib"])
   env.Append(LIBS=["avcodec", "avformat", "avfilter", "avdevice", "avutil", "swscale", "swresample"])
   if use_mingw == "no":
     env.Append(LINKFLAGS=["avcodec.lib", "avformat.lib", "avfilter.lib", "avdevice.lib", "avutil.lib", "swscale.lib", "swresample.lib"])

--- a/src/bin/gde_ffmpeg/SConstruct
+++ b/src/bin/gde_ffmpeg/SConstruct
@@ -14,7 +14,7 @@ if platform == "linux": # Linux
   env.Append(LIBS=["avcodec", "avformat", "avfilter", "avdevice", "avutil", "swscale", "swresample"])
   if ci == "yes":
     env.Append(CPPPATH=["ffmpeg-bin/include"])
-    env.Append(LIBPATH=["ffmpeg-bin/bin"])
+    env.Append(LIBPATH=["ffmpeg-bin/lib"])
 elif platform == "windows": # Windows
   print("Windows system detected")
   # First compiling ffmpeg

--- a/src/bin/gde_ffmpeg/build-ffmpeg.sh
+++ b/src/bin/gde_ffmpeg/build-ffmpeg.sh
@@ -18,6 +18,8 @@ ffmpeg_bin_folder="$script_dir/ffmpeg-bin"
 
 mkdir -p "$ffmpeg_bin_folder"
 cd "$ffmpeg_source_folder" || exit -1
+echo "Updating ffmpeg submodule ..."
+git pull
 
 config_extra_args=""
 if [ "$platform" = "windows" ]; then

--- a/src/bin/gde_ffmpeg/build-ffmpeg.sh
+++ b/src/bin/gde_ffmpeg/build-ffmpeg.sh
@@ -18,8 +18,6 @@ ffmpeg_bin_folder="$script_dir/ffmpeg-bin"
 
 mkdir -p "$ffmpeg_bin_folder"
 cd "$ffmpeg_source_folder" || exit -1
-echo "Updating ffmpeg submodule ..."
-git pull
 
 config_extra_args=""
 if [ "$platform" = "windows" ]; then


### PR DESCRIPTION
This PR attempts to add the ability to compile the GDExtension using GitHub Actions, build the GoZen executable, and maybe set some version or something. (Still a WIP)

Closes #75

Progress:
- [x] Compile GDExtension (Linux)
- [ ] Compile GDExtension (Windows)
- [ ] Compile GDExtension (MacOS)
- [ ] Build GoZen (Linux)
- [ ] Build GoZen (Windows)
- [ ] Build GoZen (MacOS)