### PR TITLE
Fix Projects Link in 'README.md' File

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *The Minimalist Video Editor*
 
 > [!IMPORTANT]  
-> GoZen is nowhere near done! Join the [discord server](https://discord.gg/BdbUf7VKYC) or look at the [Projects tab](https://github.com/users/voylin/projects/3) to know more about the development.
+> GoZen is nowhere near done! Join the [discord server](https://discord.gg/BdbUf7VKYC) or look at the [Projects tab](https://github.com/orgs/VoylinsGamedevJourney/projects/1) to know more about the development.
 
 
 ## What is GoZen 


### PR DESCRIPTION
### The Simple Changes proposed in This PR

The Link that's currently in the `README.md` File is an Outdated link that leads to a `404 Page Not Found`, Old Link is: documentation-improvement/readme-fix-projects-link

I've updated it to [this link](https://github.com/orgs/VoylinsGamedevJourney/projects/1), so New Contributors/People who are interested in the project can view GoZen's Development Progress/Road Map.