### PR TITLE
Windows workflow patch

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -108,6 +108,13 @@ jobs:
       - name: 'Copy extra DLLs'
         run: copy libs\bin\windows_x86_64\*.dll $env:EXPORT_FOLDER\
 
+      - name: 'Upload GDE'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gde-windows-bin
+          path: libs/bin
+          retention-days: 1
+
       - name: 'Upload Windows'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -102,7 +102,7 @@ jobs:
       - name: 'Export project for Windows'
         working-directory: ./src
         run: |
-          ../Godot_v${{ env.GODOT_VERSION }}-stable_win64_console.exe --import godot.project --headless --export-release Windows_x86_64 ../${{ env.EXPORT_FOLDER }}/GoZen.exe
+          ../Godot_v${{ env.GODOT_VERSION }}-stable_win64_console.exe --import godot.project --headless
           ../Godot_v${{ env.GODOT_VERSION }}-stable_win64_console.exe --headless --export-release Windows_x86_64 ../${{ env.EXPORT_FOLDER }}/GoZen.exe
 
       - name: 'Copy extra DLLs'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -33,6 +33,7 @@ jobs:
         working-directory: ./libs
         run: |
           python -c 'import sys; sys.path.append("."); import build; build.compile_ffmpeg_windows("x86_64")'
+          cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll ffmpeg/bin_windows
 
       - name: 'Upload FFmpeg binaries'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -74,6 +74,7 @@ jobs:
         working-directory: ./libs
         run: |
           python -c 'import sys; sys.path.append("."); import build; build.copy_lib_files_windows("x86_64")'
+          scons -j4 target=template_debug platform=windows arch=x86_64
           scons -j4 target=template_release platform=windows arch=x86_64
 
       - name: 'Prepare folder'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -101,8 +101,8 @@ jobs:
       - name: 'Export project for Windows'
         working-directory: ./src
         run: |
-          ../Godot_v${{ env.GODOT_VERSION }}-stable_win64.exe --import godot.project --headless --export-release Windows_x86_64 ../${{ env.EXPORT_FOLDER }}/GoZen.exe
-          ../Godot_v${{ env.GODOT_VERSION }}-stable_win64.exe --headless --export-release Windows_x86_64 ../${{ env.EXPORT_FOLDER }}/GoZen.exe
+          ../Godot_v${{ env.GODOT_VERSION }}-stable_win64_console.exe --import godot.project --headless --export-release Windows_x86_64 ../${{ env.EXPORT_FOLDER }}/GoZen.exe
+          ../Godot_v${{ env.GODOT_VERSION }}-stable_win64_console.exe --headless --export-release Windows_x86_64 ../${{ env.EXPORT_FOLDER }}/GoZen.exe
 
       - name: 'Copy extra DLLs'
         run: copy libs\bin\windows_x86_64\*.dll $env:EXPORT_FOLDER\


### PR DESCRIPTION
So ... it works when copying the dll's into the correct folder of the GoZen project and running it from the editor. However, the exported version of the editor doesn't work.

This will really need someone who knows Windows and DLL files as it is just out of my knowledge on how to deal with them. I've tried my best, but I'm stopping for the next couple of weeks to work on the Windows build. I'll resume work myself somewhere next month if nobody picked this up and made it work.